### PR TITLE
Removal of master/slave phrasing

### DIFF
--- a/python/mymodule/transmitters/_MyTransmitter.py
+++ b/python/mymodule/transmitters/_MyTransmitter.py
@@ -32,7 +32,7 @@ class MyTransmitter(pyrogue.Device):
         # Add "Disable" variable
         self.add(pyrogue.LocalVariable(
             name='Disable',
-            description='Disable the processing block. Data will just pass thorough to the next slave.',
+            description='Disable the processing block. Data will just pass thorough to the next subordinate.',
             mode='RW',
             value=False,
             localSet=lambda value: self._transmitter.setDisable(value),


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.